### PR TITLE
Add support for text input

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Show / Hide
 - `Text`
 - `Image`
 - `Container`
+- `TextField`
 
 </details>
 

--- a/lib/src/widgets/textfield.dart
+++ b/lib/src/widgets/textfield.dart
@@ -1,0 +1,25 @@
+import 'dart:html' as html;
+import 'painted_widget.dart';
+import 'widget.dart';
+
+class TextField extends PaintedWidget {
+  final String textId;
+  final String placeHolder;
+  const TextField(this.textId, this.placeHolder, {super.style});
+
+  @override
+  TextFieldNode createNode() => TextFieldNode(this);
+}
+
+class TextFieldNode
+    extends ChildlessPaintedNode<TextField, html.TextInputElement> {
+  TextFieldNode(super.widget) : super(element: html.TextInputElement());
+
+  @override
+  void initializeElement() {
+    super.initializeElement();
+
+    element.id = widget.textId;
+    element.placeholder = widget.placeHolder;
+  }
+}


### PR DESCRIPTION
A simple text input element.
The value entered can be read with Dart by
```dart
final InputElement inputElement = document.getElementById('textfield') as InputElement;
final String? text = inputElement.value;
print(text);
```